### PR TITLE
メモ登録機能のバリデーションを修正

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -114,7 +114,7 @@ class MemoController extends Controller
             'month' => 'required|integer|between:1,12',
             'day' => 'required|integer|min:1',
             'memo' => 'required|max:255',
-            'number' => 'min:-2147483648|max:2147483647',
+            'number' => 'integer|min:-2147483648|max:2147483647',
             'tag' => 'max:255'
         ],
         [


### PR DESCRIPTION
内容
・数のバリデーションが、桁数による判定となっていたため、数値による判定となるように変更
