### PR TITLE
メモ登録、更新機能のバリデーションを修正

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -125,7 +125,7 @@ class MemoController extends Controller
         }
         $memo->tag = $inputs['tag'];
         $memo->save();
-        
+
         return redirect()->route('memo.index');
     }
 
@@ -144,7 +144,7 @@ class MemoController extends Controller
             'month' => 'required|integer|between:1,12',
             'day' => 'required|integer|min:1',
             'memo' => 'required|max:255',
-            'number' => 'integer|min:-2147483648|max:2147483647',
+            'number' => 'integer|min:-2147483648|max:2147483647|nullable',
             'tag' => 'max:255'
         ],
         [


### PR DESCRIPTION
内容
・前回の修正時に、数のバリデーションにintegerを指定したことにより、nullが許容されなくなったため、nullを許容するように変更