### PR TITLE
メモ入力、編集機能の日の選択制限を解除

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -38,10 +38,8 @@ class MemoController extends Controller
             $month = date('n');
             $day = date('j');
         }
-        // 月末の日付
-        $lastDay = Carbon::create($year, $month)->lastOfMonth()->day;
 
-        return view('input', compact('year', 'month', 'day', 'lastDay'));
+        return view('input', compact('year', 'month', 'day'));
     }
 
     /**
@@ -93,10 +91,8 @@ class MemoController extends Controller
         $year = $date[0];
         $month = $date[1];
         $day = $date[2];
-        // 月末の日付
-        $lastDay = Carbon::create($year, $month)->lastOfMonth()->day;
 
-        return view('edit', compact('memo', 'year', 'month', 'day', 'lastDay'));
+        return view('edit', compact('memo', 'year', 'month', 'day'));
     }
 
     /**

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -33,7 +33,7 @@
               <dev>月</dev>
               <dev>
                 <select name='day' class='border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm'>
-                  @for ($i = 1; $i <= $lastDay; $i++)
+                  @for ($i = 1; $i <= 31; $i++)
                     @if ($i == $day)
                       <option value="{{ $i }}" selected>{{ $i }}</option>
                     @else

--- a/resources/views/input.blade.php
+++ b/resources/views/input.blade.php
@@ -32,7 +32,7 @@
               <dev>月</dev>
               <dev>
                 <select name='day' class='border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm'>
-                  @for ($i = 1; $i <= $lastDay; $i++)
+                  @for ($i = 1; $i <= 31; $i++)
                     @if ($i == $day)
                       <option value="{{ $i }}" selected>{{ $i }}</option>
                     @else


### PR DESCRIPTION
内容
・メモ入力、編集画面の日を、最初に表示した年月の月末までの選択範囲としていたので、年月を変更した場合、選択できない日が存在していたため、日は常に31日まで選択できるように変更